### PR TITLE
void transactions on fail

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
   Exclude:
     - 'spec/dummy/**/*'
     - 'vendor/bundle/**/*'
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.6
 
 # Sometimes I believe this reads better
 # This also causes spacing issues on multi-line fixes
@@ -64,7 +64,7 @@ Layout/ElseAlignment:
 Layout/IndentationWidth:
   Enabled: false
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Enabled: false
 
 Layout/ClosingParenthesisIndentation:
@@ -73,13 +73,13 @@ Layout/ClosingParenthesisIndentation:
 Layout/MultilineMethodCallIndentation:
   Enabled: false
 
-Layout/IndentArray:
+Layout/FirstArrayElementIndentation:
   Enabled: false
 
-Layout/IndentHash:
+Layout/FirstHashElementIndentation:
   Enabled: false
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 
 # From http://relaxed.ruby.style/
@@ -199,7 +199,7 @@ Lint/AssignmentInCondition:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#lintassignmentincondition
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Exclude:
     - 'Rakefile'
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'solidus', github: 'solidusio/solidus', branch: branch
 # Provides basic authentication functionality for testing parts of your engine
 gem 'solidus_auth_devise'
 gem 'deface'
+gem 'pry-nav'
 
 if branch == 'master' || branch >= 'v2.3'
   gem 'rails', '~> 5.1.0' # HACK: broken bundler dependency resolution

--- a/app/controllers/spree/paybright_controller.rb
+++ b/app/controllers/spree/paybright_controller.rb
@@ -58,7 +58,6 @@ module Spree
       )
 
       begin
-        raise StandardError
         @payment.complete!
         advance_and_complete(@payment.order)
       rescue StandardError

--- a/app/controllers/spree/paybright_controller.rb
+++ b/app/controllers/spree/paybright_controller.rb
@@ -65,7 +65,8 @@ module Spree
           @payment.void
         end
 
-        return [false, 'Something went wrong with the order. Your Paybright application has been voided. Try to order again.']
+        message = I18n.t(:paybright_error, 'Something went wrong with the order. Your Paybright application has been voided. Try to order again.')
+        return [false, message]
       end
 
       [true, ""]

--- a/app/controllers/spree/paybright_controller.rb
+++ b/app/controllers/spree/paybright_controller.rb
@@ -58,6 +58,7 @@ module Spree
       )
 
       begin
+        raise StandardError
         @payment.complete!
         advance_and_complete(@payment.order)
       rescue StandardError

--- a/lib/solidus_paybright/factories.rb
+++ b/lib/solidus_paybright/factories.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :paybright_payment_method, class: Spree::PaymentMethod::Paybright do
-    name "Paybright"
+    name { "Paybright" }
   end
 
   factory :paybright_payment, class: Spree::Payment do

--- a/spec/controllers/spree/paybright_controller_spec.rb
+++ b/spec/controllers/spree/paybright_controller_spec.rb
@@ -1,3 +1,4 @@
+require "pry"
 require "spec_helper"
 
 describe Spree::PaybrightController, type: :controller do
@@ -152,6 +153,26 @@ describe Spree::PaybrightController, type: :controller do
             x_reference: 0
           })
         ).to redirect_to "http://test.host/cart"
+      end
+    end
+
+    context "with an errored order" do
+      before do
+        allow_any_instance_of(Spree::Payment).to receive(:complete!).and_raise(StandardError)
+      end
+
+      it "redirects to the payment step" do
+        expect_any_instance_of(Spree::Payment).to receive(:void).once
+
+        expect(
+          get(:complete, params: correct_params)
+        ).to redirect_to "http://test.host/checkout/payment"
+      end
+
+      it "shows a flash message" do
+        get(:complete, params: correct_params)
+
+        expect(flash[:error]).to match(/Something went wrong with the order. Your Paybright application has been voided. Try to order again./)
       end
     end
   end

--- a/spec/controllers/spree/paybright_controller_spec.rb
+++ b/spec/controllers/spree/paybright_controller_spec.rb
@@ -158,6 +158,7 @@ describe Spree::PaybrightController, type: :controller do
 
     context "with an errored order" do
       before do
+        allow(I18n).to receive(:t).and_return("Something went wrong with the order. Your Paybright application has been voided. Try to order again.")
         allow_any_instance_of(Spree::Payment).to receive(:complete!).and_raise(StandardError)
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -86,6 +86,10 @@ RSpec.configure do |config|
     Spree::Core::Engine.routes.default_url_options = { host: "example.com" }
   end
 
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+  config.filter_run_when_matching(:focus)
+
   # Before each spec check if it is a Javascript test and switch between using database transactions or not where necessary.
   config.before :each do
     DatabaseCleaner.strategy = RSpec.current_example.metadata[:js] ? :truncation : :transaction


### PR DESCRIPTION
Currently, if anything goes wrong with `payment.complete!` or  `advance_and_complete(@payment.order)` , the payment gets stuck in an `invalid` state (because solidus has a method called `invalidate_old_payments` even though the loan went through on paybright side. this is a terrible state to be in, and if something goes wrong with the order, the loan should be immediately `voided` so the user can just retry the order again. 